### PR TITLE
Fix max call stack exceeded error

### DIFF
--- a/src/core/action.ts
+++ b/src/core/action.ts
@@ -53,7 +53,7 @@ export class Action {
    * @memberOf Action
    */
   public static get lastAction() {
-    return Action.lastAction
+    return Action._lastAction
   }
 
   /**


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/6880914/31651734-6d6f99c6-b33a-11e7-8d9a-21bc357c87af.png)

Action.lastAction threw max call stack exceeded error as the getter was getting called recursively. Fixing the typo seems to solve the error